### PR TITLE
Add registring keypair to maintainers

### DIFF
--- a/cycle1/public/scripts/init.js
+++ b/cycle1/public/scripts/init.js
@@ -225,8 +225,8 @@ window.addEventListener('DOMContentLoaded', _ => {
   var app = Elm.Main.init({
     flags: {
       address: encode(nacl.sign.keyPair().publicKey),
-      // maybeKeyPair: null,
-      maybeKeyPair: people.juliendonck.keyPair,
+      maybeKeyPair: null,
+      // maybeKeyPair: people.juliendonck.keyPair,
       maybeWallet: document.getElementById('wallet') ? 'webext' : null,
       pendingTransactions: initialTransactions,
       projects: initialProjects,

--- a/cycle1/src/KeyPair.elm
+++ b/cycle1/src/KeyPair.elm
@@ -1,4 +1,13 @@
-module KeyPair exposing (ID, KeyPair, decode, decoder, equal, id, toString)
+module KeyPair exposing
+    ( ID
+    , KeyPair
+    , decode
+    , decoder
+    , empty
+    , equal
+    , id
+    , toString
+    )
 
 import Json.Decode as Decode
 
@@ -13,6 +22,11 @@ type alias PubKey =
 
 type KeyPair
     = KeyPair ID PubKey
+
+
+empty : KeyPair
+empty =
+    KeyPair "" ""
 
 
 id : KeyPair -> ID

--- a/cycle1/src/Main.elm
+++ b/cycle1/src/Main.elm
@@ -17,6 +17,7 @@ import Page.Home
 import Page.NotFound
 import Page.Project
 import Page.Register
+import Person
 import Project exposing (Project)
 import Project.Address as Address exposing (Address)
 import Route exposing (Route)
@@ -115,7 +116,7 @@ init flags url navKey =
             Route.fromUrl url
 
         page =
-            pageFromRoute address projects maybeRoute
+            pageFromRoute address projects maybeKeyPair maybeRoute
 
         maybeOverlay =
             overlay page maybeWallet maybeKeyPair pendingTransactions
@@ -237,7 +238,7 @@ update msg model =
                     Route.fromUrl url
 
                 page =
-                    pageFromRoute model.address model.projects maybeRoute
+                    pageFromRoute model.address model.projects model.keyPair maybeRoute
 
                 ov =
                     overlay page model.wallet model.keyPair model.pendingTransactions
@@ -584,8 +585,8 @@ overlay page maybeWallet maybeKeyPair txs =
                 Nothing
 
 
-pageFromRoute : Address -> List Project -> Maybe Route -> Page
-pageFromRoute newAddr projects maybeRoute =
+pageFromRoute : Address -> List Project -> Maybe KeyPair -> Maybe Route -> Page
+pageFromRoute newAddr projects maybeKeyPair maybeRoute =
     case Debug.log "Main.pageFromRoute" maybeRoute of
         Just Route.Home ->
             Home
@@ -599,7 +600,19 @@ pageFromRoute newAddr projects maybeRoute =
                     Project project
 
         Just Route.Register ->
-            Register <| Page.Register.init newAddr
+            let
+                keyPair =
+                    case maybeKeyPair of
+                        Just kp ->
+                            kp
+
+                        Nothing ->
+                            KeyPair.empty
+
+                owner =
+                    Person.withKeyPair keyPair
+            in
+            Register <| Page.Register.init newAddr owner
 
         _ ->
             NotFound

--- a/cycle1/src/Overlay/WalletSetup.elm
+++ b/cycle1/src/Overlay/WalletSetup.elm
@@ -165,7 +165,11 @@ viewPick =
             , Element.width (Element.px 240)
             , Element.paddingEach { top = 0, right = 0, bottom = 32, left = 0 }
             ]
-            [ Button.custom [ Element.width Element.fill ] Color.pink Color.white "Firefox add-on"
+            [ Element.link
+                [ Element.width Element.fill ]
+                { url = "https://addons.mozilla.org/en-US/firefox/addon/oscoin-devnet-wallet/"
+                , label = Button.custom [ Element.width Element.fill ] Color.pink Color.white "Firefox add-on"
+                }
             , Button.custom [ Element.width Element.fill ] Color.blue Color.white "Mobile app"
             , Button.custom [ Element.width Element.fill ] Color.green Color.white "Ledger Nano S"
             , Button.custom [ Element.width Element.fill ] Color.bordeaux Color.white "macOS app"

--- a/cycle1/src/Page/Project/People.elm
+++ b/cycle1/src/Page/Project/People.elm
@@ -2,6 +2,7 @@ module Page.Project.People exposing (view)
 
 import Atom.Button as Button
 import Atom.Heading as Heading
+import Atom.Icon as Icon
 import Element exposing (Element)
 import Element.Border as Border
 import Element.Font
@@ -141,17 +142,10 @@ viewTopPeopleSingle person =
         , Element.paddingEach { top = 0, right = 0, bottom = 24, left = 0 }
         , Element.alignTop
         ]
-        [ Element.image
-            [ Element.height (Element.px 48)
-            , Element.width (Element.px 48)
-            , Border.color Color.lightGrey
-            , Border.rounded 24
-            , Border.width 1
-            , Element.clip
-            ]
-            { src = Person.imageUrl person
-            , description = "avatar"
-            }
+        -- AVATAR
+        [ viewAvatar <| Person.imageUrl person
+
+        -- NAME
         , Element.column
             [ Element.spacing 4 ]
             [ Element.el
@@ -165,3 +159,22 @@ viewTopPeopleSingle person =
                 Element.text "Core maintainer"
             ]
         ]
+
+
+viewAvatar : String -> Element msg
+viewAvatar imgUrl =
+    if imgUrl == "" then
+        Element.el [] <| Icon.largeLogoCircle Color.lightGrey
+
+    else
+        Element.image
+            [ Element.height (Element.px 48)
+            , Element.width (Element.px 48)
+            , Border.color Color.lightGrey
+            , Border.rounded 24
+            , Border.width 1
+            , Element.clip
+            ]
+            { src = imgUrl
+            , description = "avatar"
+            }

--- a/cycle1/src/Page/Register.elm
+++ b/cycle1/src/Page/Register.elm
@@ -11,10 +11,10 @@ import Element.Font
 import Element.Input as Input
 import Molecule.ContractPreview as ContractPreview
 import Molecule.ProjectMeta as ProjectMeta
-import Molecule.Rule as Rule
 import Page.Register.Contract as Contract
+import Person exposing (Person)
 import Project exposing (Project)
-import Project.Address as Address exposing (Address)
+import Project.Address exposing (Address)
 import Project.Contract as Contract
 import Project.Meta as Meta
 import Style.Color as Color
@@ -39,9 +39,9 @@ type Model
     = Model Step Project FieldError
 
 
-init : Address -> Model
-init addr =
-    Model Info (Project.withAddress addr) (FieldError False False)
+init : Address -> Person -> Model
+init addr owner =
+    Model Info (Project.mapMaintainers (\_ -> [ owner ]) <| Project.withAddress addr) (FieldError False False)
 
 
 

--- a/cycle1/src/Person.elm
+++ b/cycle1/src/Person.elm
@@ -4,6 +4,7 @@ module Person exposing
     , imageUrl
     , keyPair
     , name
+    , withKeyPair
     )
 
 import Json.Decode as Decode
@@ -20,6 +21,11 @@ type alias ImageUrl =
 
 type Person
     = Person KeyPair Name ImageUrl
+
+
+withKeyPair : KeyPair -> Person
+withKeyPair kp =
+    Person kp "unknonw" ""
 
 
 imageUrl : Person -> ImageUrl

--- a/cycle1/src/Project.elm
+++ b/cycle1/src/Project.elm
@@ -13,6 +13,7 @@ module Project exposing
     , isMaintainer
     , maintainers
     , mapContract
+    , mapMaintainers
     , mapMeta
     , meta
     , prettyAddress
@@ -117,6 +118,11 @@ meta (Project data) =
 contributors : Project -> List Person
 contributors (Project data) =
     data.contributors
+
+
+mapMaintainers : (List Person -> List Person) -> Project -> Project
+mapMaintainers change (Project data) =
+    Project { data | maintainers = change data.maintainers }
 
 
 maintainers : Project -> List Person


### PR DESCRIPTION
In order to show the right state of the project page after the registration we need to the current key pair to the list of maintainers. As we don't have any further identity for now we assume an unknown
person without an avatar/imageUrl present.